### PR TITLE
Feature - добавлена обработка ошибок и их отображение в snackbar

### DIFF
--- a/SurfSummerSchoolProject.xcodeproj/project.pbxproj
+++ b/SurfSummerSchoolProject.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		3A1B1B9128AF819D000346D7 /* AlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1B1B9028AF819D000346D7 /* AlertView.swift */; };
 		3A21D05828AF916300ECC401 /* PhoneMask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A21D05728AF916300ECC401 /* PhoneMask.swift */; };
 		3A21D05B28AF94D400ECC401 /* ButtonActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A21D05A28AF94D400ECC401 /* ButtonActivityIndicator.swift */; };
+		3A21D05E28AFDC9000ECC401 /* ErrorTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A21D05D28AFDC9000ECC401 /* ErrorTypes.swift */; };
 		3A4190FC28ACFD7D00204734 /* LogoutRequestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4190FB28ACFD7C00204734 /* LogoutRequestModel.swift */; };
 		3A4190FE28ACFD8900204734 /* LogoutResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4190FD28ACFD8900204734 /* LogoutResponseModel.swift */; };
 		3A41910028ACFD9D00204734 /* LogoutService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4190FF28ACFD9D00204734 /* LogoutService.swift */; };
@@ -75,6 +76,7 @@
 		3A1B1B9028AF819D000346D7 /* AlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertView.swift; sourceTree = "<group>"; };
 		3A21D05728AF916300ECC401 /* PhoneMask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneMask.swift; sourceTree = "<group>"; };
 		3A21D05A28AF94D400ECC401 /* ButtonActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonActivityIndicator.swift; sourceTree = "<group>"; };
+		3A21D05D28AFDC9000ECC401 /* ErrorTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorTypes.swift; sourceTree = "<group>"; };
 		3A4190FB28ACFD7C00204734 /* LogoutRequestModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoutRequestModel.swift; sourceTree = "<group>"; };
 		3A4190FD28ACFD8900204734 /* LogoutResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoutResponseModel.swift; sourceTree = "<group>"; };
 		3A4190FF28ACFD9D00204734 /* LogoutService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoutService.swift; sourceTree = "<group>"; };
@@ -171,6 +173,14 @@
 				3A21D05A28AF94D400ECC401 /* ButtonActivityIndicator.swift */,
 			);
 			path = ButtonActivityIndicator;
+			sourceTree = "<group>";
+		};
+		3A21D05C28AFDC8000ECC401 /* ErrorTypes */ = {
+			isa = PBXGroup;
+			children = (
+				3A21D05D28AFDC9000ECC401 /* ErrorTypes.swift */,
+			);
+			path = ErrorTypes;
 			sourceTree = "<group>";
 		};
 		3A4190FA28ACFD4000204734 /* LogoutService */ = {
@@ -401,6 +411,7 @@
 		3AE4172428A12DD3009E1AFE /* Storages */ = {
 			isa = PBXGroup;
 			children = (
+				3A21D05C28AFDC8000ECC401 /* ErrorTypes */,
 				3A41910128AD3CCB00204734 /* ProfileInfoStorage */,
 				3A6ADAFB28AA431500461A46 /* ImagesStorage */,
 				3A6ADAF828A9750C00461A46 /* ColorsStorage */,
@@ -637,6 +648,7 @@
 				3A1B1B9128AF819D000346D7 /* AlertView.swift in Sources */,
 				3A82DD61289C4A9100453EE2 /* ProfileViewController.swift in Sources */,
 				3AFC3A6628AC02480077E14C /* SnackbarModel.swift in Sources */,
+				3A21D05E28AFDC9000ECC401 /* ErrorTypes.swift in Sources */,
 				3A4190FC28ACFD7D00204734 /* LogoutRequestModel.swift in Sources */,
 				3AC3BDBA28AC43DA0036762E /* ProfileModel.swift in Sources */,
 				3A6ADAFA28A9752300461A46 /* ColorsStorage.swift in Sources */,

--- a/SurfSummerSchoolProject/AuthFlow/AuthViewController.swift
+++ b/SurfSummerSchoolProject/AuthFlow/AuthViewController.swift
@@ -47,9 +47,23 @@ class AuthViewController: UIViewController {
                                 delegate.window?.rootViewController = mainViewController
                             }
                         }
-                    case .failure:
+                    case .failure (let error):
                         DispatchQueue.main.async {
-                            let model = SnackbarModel(text: "Логин или пароль введен неправильно")
+                            var snackbarText = "Что-то пошло не так"
+                            
+                            if let currentError = error as? PossibleErrors {
+                                switch currentError {
+                                case .badRequest(let response):
+                                    if response["message"] == "Неверный логин/пароль" {
+                                        snackbarText = "Логин или пароль введен неправильно"
+                                    }
+                                case .noNetworkConnection:
+                                    snackbarText = "Отсутствует интернет соединение"
+                                default:
+                                    snackbarText = "Что-то пошло не так"
+                                }
+                            }
+                            let model = SnackbarModel(text: snackbarText)
                             let snackbar = SnackbarView(model: model)
                             guard let `self` = self else { return }
                             snackbar.showSnackBar(on: self, with: model)

--- a/SurfSummerSchoolProject/MainFlow/AllPostsModule/AllPostsModel.swift
+++ b/SurfSummerSchoolProject/MainFlow/AllPostsModule/AllPostsModel.swift
@@ -10,12 +10,13 @@ import UIKit
 
 final class AllPostsModel {
     static let shared = AllPostsModel.init()
+    static var errorDescription: String = "Что-то пошло не так"
+    
     enum LoadState {
         case idle
         case success
         case error
     }
-    
     var currentState: LoadState = .idle
     var didPostsUpdated: (()->Void)?
     var didPostsFetchErrorHappened: (()->Void)?
@@ -47,9 +48,17 @@ final class AllPostsModel {
                 self?.didPostsUpdated?()
                 
             case .failure(let error):
+                if let networkError = error as? PossibleErrors {
+                    switch networkError {
+                    case .noNetworkConnection:
+                        AllPostsModel.errorDescription = "Отсутствует интернет-соединение \nПопробуйте позже"
+                    default:
+                        AllPostsModel.errorDescription = "Что-то пошло не так"
+                    }
+                }
+                
                 self?.currentState = .error
                 self?.didPostsFetchErrorHappened?()
-                print(error)
             }
         }
     }

--- a/SurfSummerSchoolProject/MainFlow/AllPostsModule/AllPostsViewController.swift
+++ b/SurfSummerSchoolProject/MainFlow/AllPostsModule/AllPostsViewController.swift
@@ -84,7 +84,8 @@ private extension AllPostsViewController {
                 self.activityIndicatorView.isHidden = true
                 self.fetchPostsErrorVC.view.alpha = 1
                 } else {
-                    let model = SnackbarModel(text: "Не удалось загрузить данные")
+                    let textForSnackBar = AllPostsModel.errorDescription
+                    let model = SnackbarModel(text: textForSnackBar)
                     let snackbar = SnackbarView(model: model)
                     snackbar.showSnackBar(on: self, with: model)
                 }

--- a/SurfSummerSchoolProject/MainFlow/FavoritePostsModule/FavoritePostsViewController.swift
+++ b/SurfSummerSchoolProject/MainFlow/FavoritePostsModule/FavoritePostsViewController.swift
@@ -36,8 +36,8 @@ class FavoritePostsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureAppearance()
-        configureModel()
         configurePullToRefresh()
+        configureModel()
     }
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -110,6 +110,7 @@ private extension FavoritePostsViewController {
         refreshControl.endRefreshing()
         }
     func emptyFavoritesNotification() {
+        refreshControl.removeFromSuperview()
         view.bringSubviewToFront(emptyFavoritesNotificationImage)
         view.bringSubviewToFront(emptyFavoritesNotificationText)
         emptyFavoritesNotificationImage.image = ConstantImages.sadSmile
@@ -117,6 +118,7 @@ private extension FavoritePostsViewController {
         emptyFavoritesNotificationText.text = "В избранном пусто"
     }
     func nonEmptyFavoritesNotification() {
+        configurePullToRefresh()
         emptyFavoritesNotificationImage.image = UIImage()
         emptyFavoritesNotificationText.text = ""
     }

--- a/SurfSummerSchoolProject/MainFlow/ProfileModule/ProfileViewController.swift
+++ b/SurfSummerSchoolProject/MainFlow/ProfileModule/ProfileViewController.swift
@@ -38,10 +38,20 @@ class ProfileViewController: UIViewController {
                                 delegate.window?.rootViewController = navigationAuthViewController
                             }
                         }
-                    case .failure:
+                    case .failure(let error):
                         DispatchQueue.main.async {
                             buttonActivityIndicator.hideButtonLoading()
-                            let model = SnackbarModel(text: "Не получилось выйти")
+                            var textForSnackbar = "Не удалось выйти, попробуйте еще раз"
+                            if let currentError = error as? PossibleErrors {
+                                switch currentError {
+                                case .noNetworkConnection:
+                                    textForSnackbar = "Отсутствует интернет-соединение \nПопробуйте позже"
+                                default:
+                                    textForSnackbar = "Не удалось выйти, попробуйте еще раз"
+                                }
+                            }
+                            
+                            let model = SnackbarModel(text: textForSnackbar)
                             let snackbar = SnackbarView(model: model)
                             guard let `self` = self else { return }
                             snackbar.showSnackBar(on: self, with: model)

--- a/SurfSummerSchoolProject/Services/Networking/AuthService/AuthService.swift
+++ b/SurfSummerSchoolProject/Services/Networking/AuthService/AuthService.swift
@@ -8,29 +8,28 @@
 import Foundation
 
 struct AuthService {
-
-     let dataTask = BaseNetworkTask<AuthRequestModel, AuthResponseModel>(
-         inNeedInjectToken: false,
-         method: .post,
-         path: "auth/login"
-     )
-
-     func performLoginRequestAndSaveToken(
-         credentials: AuthRequestModel,
-         _ onResponseWasReceived: @escaping (_ result: Result<AuthResponseModel, Error>) -> Void
-     ) {
-         dataTask.performRequest(input: credentials) { result in
-                     if case let .success(responseModel) = result {
-                         do {
-                             try dataTask.tokenStorage.set(newToken: TokenContainer(token: responseModel.token, receivingDate: .now))
-                             try dataTask.profileStorage.set(profile: responseModel.user_info)
-                         } catch {
-                            
-                             // TODO: - Handle error if token not was received from server
-                         }
-                     }
-                     onResponseWasReceived(result)
-                 }
-     }
-
- }
+    
+    let dataTask = BaseNetworkTask<AuthRequestModel, AuthResponseModel>(
+        inNeedInjectToken: false,
+        method: .post,
+        path: "auth/login"
+    )
+    
+    func performLoginRequestAndSaveToken(
+        credentials: AuthRequestModel,
+        _ onResponseWasReceived: @escaping (_ result: Result<AuthResponseModel, Error>) -> Void
+    ) {
+        dataTask.performRequest(input: credentials) { result in
+            if case let .success(responseModel) = result {
+                do {
+                    try dataTask.tokenStorage.set(newToken: TokenContainer(token: responseModel.token, receivingDate: .now))
+                    try dataTask.profileStorage.set(profile: responseModel.user_info)
+                } catch {
+                    onResponseWasReceived(result)
+                }
+            } else {
+                onResponseWasReceived(result)
+            }
+        }
+    }
+}

--- a/SurfSummerSchoolProject/Services/Networking/AuthService/AuthService.swift
+++ b/SurfSummerSchoolProject/Services/Networking/AuthService/AuthService.swift
@@ -24,6 +24,7 @@ struct AuthService {
                 do {
                     try dataTask.tokenStorage.set(newToken: TokenContainer(token: responseModel.token, receivingDate: .now))
                     try dataTask.profileStorage.set(profile: responseModel.user_info)
+                    onResponseWasReceived(result)
                 } catch {
                     onResponseWasReceived(result)
                 }

--- a/SurfSummerSchoolProject/Services/Networking/Core/BaseNetworkTask.swift
+++ b/SurfSummerSchoolProject/Services/Networking/Core/BaseNetworkTask.swift
@@ -79,6 +79,14 @@ struct BaseNetworkTask<AbstractInput: Encodable, AbstractOutput: Decodable>: Net
                             } catch {
                                 onResponseWasReceived(.failure(PossibleErrors.unknownError))
                             }
+                        case 401:
+                            do {
+                                let mappedModel = try JSONDecoder().decode(AbstractOutput.self, from: data)
+                                saveResponseToCache(response, cachedData: data, by: request)
+                                onResponseWasReceived(.success(mappedModel))
+                            } catch {
+                                onResponseWasReceived(.failure(PossibleErrors.unknownError))
+                            }
                         case 400:
                             do {
                                 if let badRequest = try JSONSerialization.jsonObject(with: data) as? [String:String] {

--- a/SurfSummerSchoolProject/Services/Networking/Core/BaseNetworkTask.swift
+++ b/SurfSummerSchoolProject/Services/Networking/Core/BaseNetworkTask.swift
@@ -8,174 +8,189 @@
 import Foundation
 
 struct BaseNetworkTask<AbstractInput: Encodable, AbstractOutput: Decodable>: NetworkTask {
-
-     // MARK: - NetworkTask
-
-     typealias Input = AbstractInput
-     typealias Output = AbstractOutput
-
-     var baseURL: URL? {
-         URL(string: "https://pictures.chronicker.fun/api")
-     }
-
-     let path: String
-     let method: NetworkMethod
-     let session: URLSession = URLSession(configuration: .default)
-     let isNeedInjectToken: Bool
+    
+    // MARK: - NetworkTask
+    
+    typealias Input = AbstractInput
+    typealias Output = AbstractOutput
+    
+    var baseURL: URL? {
+        URL(string: "https://pictures.chronicker.fun/api")
+    }
+    
+    let path: String
+    let method: NetworkMethod
+    let session: URLSession = URLSession(configuration: .default)
+    let isNeedInjectToken: Bool
     var urlCache: URLCache {
-             URLCache.shared
-         }
-
-     var tokenStorage: TokenStorage {
-         BaseTokenStorage()
-     }
+        URLCache.shared
+    }
+    
+    var tokenStorage: TokenStorage {
+        BaseTokenStorage()
+    }
     var profileStorage: ProfileStorage {
         BaseProfileStorage()
     }
     
+    
+    // MARK: - Initializtion
+    
+    init(inNeedInjectToken: Bool, method: NetworkMethod, path: String) {
+        self.isNeedInjectToken = inNeedInjectToken
+        self.path = path
+        self.method = method
+    }
+    
+    // MARK: - NetworkTask
+    
+    func performRequest(
+        input: AbstractInput,
+        _ onResponseWasReceived: @escaping (_ result: Result<AbstractOutput, Error>) -> Void
+    ) {
+        do {
+            let request = try getRequest(with: input)
+            
+            //Закомментировано для возможности протестировать экран с состояния ошибки загрузки данных из сети. Будет раскомментировано после проверки.
+            //             if let cachedResponse = getCachedResponseFromCache(by: request) {
+            //
+            //                 let mappedModel = try JSONDecoder().decode(AbstractOutput.self, from: cachedResponse.data)
+            //
+            //                 onResponseWasReceived(.success(mappedModel))
+            //                 //return
+            //             } else {
+            
+            session.dataTask(with: request) { data, response, error in
+                if let error = error {
+                    if error.localizedDescription == "The Internet connection appears to be offline." {
+                        onResponseWasReceived(.failure(PossibleErrors.noNetworkConnection))
+                    } else {
+                    onResponseWasReceived(.failure(PossibleErrors.unknownError))
+                    }
+                    
+                } else if let data = data {
+                    if let httpResponse = response as? HTTPURLResponse {
+                        switch httpResponse.statusCode {
+                        case 200:
+                            do {
+                                let mappedModel = try JSONDecoder().decode(AbstractOutput.self, from: data)
+                                saveResponseToCache(response, cachedData: data, by: request)
+                                onResponseWasReceived(.success(mappedModel))
+                            } catch {
+                                onResponseWasReceived(.failure(PossibleErrors.unknownError))
+                            }
+                        case 400:
+                            do {
+                                if let badRequest = try JSONSerialization.jsonObject(with: data) as? [String:String] {
+                                onResponseWasReceived(.failure(PossibleErrors.badRequest(badRequest)))
+                                }
+                            } catch {
+                                onResponseWasReceived(.failure(PossibleErrors.unknownError))
+                            }
+                        default:
+                            onResponseWasReceived(.failure(PossibleErrors.unknownServerError))
+                        }
+                    }
+                    
+                } else {
+                    onResponseWasReceived(.failure(PossibleErrors.unknownError))
+                }
+            }
+            .resume()
+            //}
+        } catch {
+            onResponseWasReceived(.failure(PossibleErrors.unknownError))
+        }
+    }
+    
+}
 
-     // MARK: - Initializtion
+// MARK: - EmptyModel
 
-     init(inNeedInjectToken: Bool, method: NetworkMethod, path: String) {
-         self.isNeedInjectToken = inNeedInjectToken
-         self.path = path
-         self.method = method
-     }
-
-     // MARK: - NetworkTask
-
-     func performRequest(
-         input: AbstractInput,
-         _ onResponseWasReceived: @escaping (_ result: Result<AbstractOutput, Error>) -> Void
-     ) {
-         do {
-             let request = try getRequest(with: input)
-
-//Закомментировано для возможности протестировать экран с состояния ошибки загрузки данных из сети. Будет раскомментировано после проверки. 
-//             if let cachedResponse = getCachedResponseFromCache(by: request) {
-//
-//                 let mappedModel = try JSONDecoder().decode(AbstractOutput.self, from: cachedResponse.data)
-//
-//                 onResponseWasReceived(.success(mappedModel))
-//                 //return
-//             } else {
-
-             session.dataTask(with: request) { data, response, error in
-                 if let error = error {
-                     onResponseWasReceived(.failure(error))
-                 } else if let data = data {
-                     do {
-                         let mappedModel = try JSONDecoder().decode(AbstractOutput.self, from: data)
-                         saveResponseToCache(response, cachedData: data, by: request)
-                         onResponseWasReceived(.success(mappedModel))
-                     } catch {
-                         onResponseWasReceived(.failure(error))
-                     }
-                 } else {
-                     onResponseWasReceived(.failure(NetworkTaskError.unknownError))
-                 }
-             }
-             .resume()
-             //}
-         } catch {
-             onResponseWasReceived(.failure(error))
-         }
-     }
-
- }
-
- // MARK: - EmptyModel
-
- extension BaseNetworkTask where Input == EmptyModel {
-
-     func performRequest(_ onResponseWasReceived: @escaping (_ result: Result<AbstractOutput, Error>) -> Void) {
-         performRequest(input: EmptyModel(), onResponseWasReceived)
-     }
-
- }
+extension BaseNetworkTask where Input == EmptyModel {
+    
+    func performRequest(_ onResponseWasReceived: @escaping (_ result: Result<AbstractOutput, Error>) -> Void) {
+        performRequest(input: EmptyModel(), onResponseWasReceived)
+    }
+    
+}
 // MARK: - Cache logic
 
- private extension BaseNetworkTask {
+private extension BaseNetworkTask {
+    
+    func getCachedResponseFromCache(by request: URLRequest) -> CachedURLResponse? {
+        return urlCache.cachedResponse(for: request)
+    }
+    
+    func saveResponseToCache(_ response: URLResponse?, cachedData: Data?, by request: URLRequest) {
+        guard let response = response, let cachedData = cachedData else {
+            return
+        }
+        
+        let cachedUrlResponse = CachedURLResponse(response: response, data: cachedData)
+        urlCache.storeCachedResponse(cachedUrlResponse, for: request)
+    }
+    
+}
 
-     func getCachedResponseFromCache(by request: URLRequest) -> CachedURLResponse? {
-         return urlCache.cachedResponse(for: request)
-     }
+// MARK: - Private Methods
 
-     func saveResponseToCache(_ response: URLResponse?, cachedData: Data?, by request: URLRequest) {
-         guard let response = response, let cachedData = cachedData else {
-             return
-         }
+private extension BaseNetworkTask {
+    
+    func getRequest(with parameters: AbstractInput) throws -> URLRequest {
+        guard let url = completedURL else {
+            throw PossibleErrors.urlWasNotFound
+        }
+        
+        var request: URLRequest
+        switch method {
+        case .get:
+            let newUrl = try getUrlWithQueryParameters(for: url, parameters: parameters)
+            request = URLRequest(url: newUrl)
+        case .post:
+            request = URLRequest(url: url)
+            request.httpBody = try getParametersForBody(from: parameters)
+        }
+        request.httpMethod = method.method
+        
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        if isNeedInjectToken {
+            request.addValue("Token \(try tokenStorage.getToken().token)", forHTTPHeaderField: "Authorization")
+        }
+        
+        return request
+    }
+    
+    func getParametersForBody(from encodableParameters: AbstractInput) throws -> Data {
+        return try JSONEncoder().encode(encodableParameters)
+    }
+    
+    func getUrlWithQueryParameters(for url: URL, parameters: AbstractInput) throws -> URL {
+        guard var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
+            throw PossibleErrors.urlComponentWasNotCreated
+        }
+        
+        let parametersInDataRepresentation = try JSONEncoder().encode(parameters)
+        let parametersInDictionaryRepresentation = try JSONSerialization.jsonObject(with: parametersInDataRepresentation)
+        
+        guard let parametersInDictionaryRepresentation = parametersInDictionaryRepresentation as? [String: Any] else {
+            throw PossibleErrors.parametersIsNotValidJsonObject
+        }
+        
+        let queryItems = parametersInDictionaryRepresentation.map { key, value in
+            return URLQueryItem(name: key, value: "\(value)")
+        }
+        
+        if !queryItems.isEmpty {
+            urlComponents.queryItems = queryItems
+        }
+        
+        guard let newUrlWithQuery = urlComponents.url else {
+            throw PossibleErrors.urlWasNotFound
+        }
+        
+        return newUrlWithQuery
+    }
+    
+}
 
-         let cachedUrlResponse = CachedURLResponse(response: response, data: cachedData)
-         urlCache.storeCachedResponse(cachedUrlResponse, for: request)
-     }
-
- }
-
- // MARK: - Private Methods
-
- private extension BaseNetworkTask {
-
-     enum NetworkTaskError: Error {
-         case unknownError
-         case urlWasNotFound
-         case urlComponentWasNotCreated
-         case parametersIsNotValidJsonObject
-     }
-
-     func getRequest(with parameters: AbstractInput) throws -> URLRequest {
-         guard let url = completedURL else {
-             throw NetworkTaskError.urlWasNotFound
-         }
-
-         var request: URLRequest
-         switch method {
-         case .get:
-             let newUrl = try getUrlWithQueryParameters(for: url, parameters: parameters)
-             request = URLRequest(url: newUrl)
-         case .post:
-             request = URLRequest(url: url)
-             request.httpBody = try getParametersForBody(from: parameters)
-         }
-         request.httpMethod = method.method
-
-         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-         if isNeedInjectToken {
-             request.addValue("Token \(try tokenStorage.getToken().token)", forHTTPHeaderField: "Authorization")
-         }
-
-         return request
-     }
-
-     func getParametersForBody(from encodableParameters: AbstractInput) throws -> Data {
-         return try JSONEncoder().encode(encodableParameters)
-     }
-
-     func getUrlWithQueryParameters(for url: URL, parameters: AbstractInput) throws -> URL {
-         guard var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
-             throw NetworkTaskError.urlComponentWasNotCreated
-         }
-
-         let parametersInDataRepresentation = try JSONEncoder().encode(parameters)
-         let parametersInDictionaryRepresentation = try JSONSerialization.jsonObject(with: parametersInDataRepresentation)
-
-         guard let parametersInDictionaryRepresentation = parametersInDictionaryRepresentation as? [String: Any] else {
-             throw NetworkTaskError.parametersIsNotValidJsonObject
-         }
-
-         let queryItems = parametersInDictionaryRepresentation.map { key, value in
-             return URLQueryItem(name: key, value: "\(value)")
-         }
-
-         if !queryItems.isEmpty {
-             urlComponents.queryItems = queryItems
-         }
-
-         guard let newUrlWithQuery = urlComponents.url else {
-             throw NetworkTaskError.urlWasNotFound
-         }
-
-         return newUrlWithQuery
-     }
-
- }

--- a/SurfSummerSchoolProject/Services/Networking/LogoutService/LogoutService.swift
+++ b/SurfSummerSchoolProject/Services/Networking/LogoutService/LogoutService.swift
@@ -22,6 +22,7 @@ struct LogoutService {
                 do {
                     try dataTask.tokenStorage.removeTokenFromContainer()
                     try dataTask.profileStorage.removeProfile()
+                    onResponseWasReceived(result)
                 } catch {
                     onResponseWasReceived(result)
                 }

--- a/SurfSummerSchoolProject/Services/Networking/LogoutService/LogoutService.swift
+++ b/SurfSummerSchoolProject/Services/Networking/LogoutService/LogoutService.swift
@@ -8,28 +8,26 @@
 import Foundation
 
 struct LogoutService {
-
-     let dataTask = BaseNetworkTask<LogoutRequestModel, LogoutResponseModel>(
-         inNeedInjectToken: false,
-         method: .post,
-         path: "auth/logout"
-     )
-
-     func performLogoutRequestAndRemoveToken(_ onResponseWasReceived: @escaping (_ result: Result<LogoutResponseModel, Error>) -> Void
-     ) {
-         dataTask.performRequest(input: LogoutRequestModel()) { result in
-                     if case let .success(responseModel) = result {
-                         do {
-                             try dataTask.tokenStorage.removeTokenFromContainer()
-                             try dataTask.profileStorage.removeProfile()
-                         } catch {
-                            
-                             // TODO: - Handle error if token not was received from server
-                         }
-                     }
-
-                     onResponseWasReceived(result)
-                 }
-     }
-
- }
+    
+    let dataTask = BaseNetworkTask<LogoutRequestModel, LogoutResponseModel>(
+        inNeedInjectToken: false,
+        method: .post,
+        path: "auth/logout"
+    )
+    
+    func performLogoutRequestAndRemoveToken(_ onResponseWasReceived: @escaping (_ result: Result<LogoutResponseModel, Error>) -> Void
+    ) {
+        dataTask.performRequest(input: LogoutRequestModel()) { result in
+            if case .success(_) = result {
+                do {
+                    try dataTask.tokenStorage.removeTokenFromContainer()
+                    try dataTask.profileStorage.removeProfile()
+                } catch {
+                    onResponseWasReceived(result)
+                }
+            }
+            onResponseWasReceived(result)
+        }
+    }
+    
+}

--- a/SurfSummerSchoolProject/Services/Networking/PicturesService/PictureResponseModel.swift
+++ b/SurfSummerSchoolProject/Services/Networking/PicturesService/PictureResponseModel.swift
@@ -17,7 +17,7 @@ struct PictureResponseModel: Decodable {
      let photoUrl: String
 
      var date: Date {
-         Date(timeIntervalSince1970: publicationDate / 1000)/// Почему? В чем прикол присылать дату в миллисекундах?
+         Date(timeIntervalSince1970: publicationDate / 1000)
      }
 
      // MARK: - Private Properties

--- a/SurfSummerSchoolProject/Storages/ErrorTypes/ErrorTypes.swift
+++ b/SurfSummerSchoolProject/Storages/ErrorTypes/ErrorTypes.swift
@@ -1,0 +1,19 @@
+//
+//  ErrorTypes.swift
+//  SurfSummerSchoolProject
+//
+//  Created by Антон Голубейков on 19.08.2022.
+//
+
+import Foundation
+
+//MARK: - Possible errors
+enum PossibleErrors: Error {
+    case unknownError
+    case urlWasNotFound
+    case urlComponentWasNotCreated
+    case parametersIsNotValidJsonObject
+    case badRequest([String:String])
+    case noNetworkConnection
+    case unknownServerError
+}

--- a/SurfSummerSchoolProject/SupportingViews/Posts load error/PostsLoadErrorViewController.swift
+++ b/SurfSummerSchoolProject/SupportingViews/Posts load error/PostsLoadErrorViewController.swift
@@ -11,11 +11,13 @@ class PostsLoadErrorViewController: UIViewController {
 
     var refreshButtonAction: ()->Void = {}
     
+    @IBOutlet weak var errorDescription: UILabel!
     @IBAction private func refreshButton(_ sender: Any) {
         refreshButtonAction()
         self.view.alpha = 0
     }
     override func viewDidLoad() {
         super.viewDidLoad()
+        errorDescription.text = "Не удалось загрузить ленту \nОбновите экран или попробуйте позже"
     }
 }

--- a/SurfSummerSchoolProject/SupportingViews/Posts load error/PostsLoadErrorViewController.xib
+++ b/SurfSummerSchoolProject/SupportingViews/Posts load error/PostsLoadErrorViewController.xib
@@ -10,6 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PostsLoadErrorViewController" customModule="SurfSummerSchoolProject" customModuleProvider="target">
             <connections>
+                <outlet property="errorDescription" destination="yoy-rg-LOi" id="se0-Eq-7JD"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>


### PR DESCRIPTION
Добавлена обработка ошибок и их отображение в snackbar. Есть 3 типа ошибки, которые отображаются пользователю в snackbar: 1) "Неправильный логин/пароль" на экране аутентификации, 2) "Отсутствует интернет-соединение" для всех экранов, 3) "Что-то пошло не так" для всех экранов (для типов ошибок, про которые пользователю не нужно знать). Для возможность протестировать zero-screen на вкладке Главная временно закомментировал кэширование url-запросов.
Также заодно исправлен мелкий баг возможности сделать pull to refresh на пустой вкладке Избранное. 

Как проверить: 
1) На экране аутентификации попробовать войти с неправильными логин/паролем при включенном и выключенном интернете. Убедиться, что в snackbar приходит 2 разные ошибки. 
2) На вкладке Главная попробовать сделать pull to refresh при выключенном интернете. 
3) На вкладке Профиль попробовать выйти с выключенным интернетом. 

<img width="130" alt="Снимок экрана 2022-08-19 в 19 26 01" src="https://user-images.githubusercontent.com/47087482/185664733-ab57ae39-8b93-4d2a-a0a8-db9ac9760045.png"><img width="130" alt="Снимок экрана 2022-08-19 в 19 26 38" src="https://user-images.githubusercontent.com/47087482/185664778-74ffc4ef-1d25-486a-8994-f74472811c79.png"><img width="130" alt="Снимок экрана 2022-08-19 в 18 40 04" src="https://user-images.githubusercontent.com/47087482/185664808-4c3a0e56-9618-4f2b-9659-7c2f68aee614.png"><img width="130" alt="Снимок экрана 2022-08-19 в 18 38 51" src="https://user-images.githubusercontent.com/47087482/185664873-61f86cfe-e6bb-498e-8bd1-2edebd8a89cc.png">

